### PR TITLE
fix: create static components map for loadable components

### DIFF
--- a/gatsby-theme-kickstartds/.gitignore
+++ b/gatsby-theme-kickstartds/.gitignore
@@ -1,1 +1,2 @@
 src/assets/*
+src/components/kickstartDSComponentsMap.ts

--- a/gatsby-theme-kickstartds/create/createComponentsMap.js
+++ b/gatsby-theme-kickstartds/create/createComponentsMap.js
@@ -1,0 +1,28 @@
+const fs = require('fs')
+const path = require('path');
+const baseExports = require('@kickstartds/base/lib/exports.json');
+const blogExports = require('@kickstartds/blog/lib/exports.json');
+const contentExports = require('@kickstartds/content/lib/exports.json');
+
+const reducer = (mod) => (prev, [key, value]) => {
+  if (key !== "index.js" && key.indexOf('/') === -1 && value.length) {
+    prev += `'${key}': loadable(() => import('@kickstartds/${mod}/lib/${key}/index.js'), { resolveComponent: (exports) => exports.${value[0]} }),\n`
+  }
+  return prev
+};
+
+const base = Object.entries(baseExports).reduce(reducer("base"), '');
+const blog = Object.entries(blogExports).reduce(reducer("blog"), '');
+const content = Object.entries(contentExports).reduce(reducer("content"), '');
+
+const dest = path.resolve(__dirname, '../src/components', 'kickstartDSComponentsMap.ts');
+const file = `
+import loadable from '@loadable/component';
+
+export default {
+  ${base}
+  ${blog}
+  ${content}
+};
+`;
+fs.writeFileSync(dest, file);

--- a/gatsby-theme-kickstartds/package.json
+++ b/gatsby-theme-kickstartds/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "gatsby build",
     "clean": "gatsby clean",
-    "develop": "gatsby develop"
+    "develop": "gatsby develop",
+    "postinstall": "node ./create/createComponentsMap.js"
   },
   "peerDependencies": {
     "gatsby": "^3.8.1",

--- a/gatsby-theme-kickstartds/src/components/KickstartDSPageComponent.tsx
+++ b/gatsby-theme-kickstartds/src/components/KickstartDSPageComponent.tsx
@@ -1,41 +1,11 @@
 import React from 'react';
 import { FunctionComponent } from 'react';
-import loadable from '@loadable/component';
 
 import { KickstartDSLayout } from './KickstartDSLayoutComponent';
+import components from "./kickstartDSComponentsMap";
 
-import baseExports from '@kickstartds/base/lib/exports.json';
-import blogExports from '@kickstartds/blog/lib/exports.json';
-import contentExports from '@kickstartds/content/lib/exports.json';
-
-const components = {};
 const componentCounter = [];
-
 const typeResolutionField = 'type';
-
-Object.entries(baseExports).forEach(([key, value]) => {
-  if (key.indexOf('/') === -1 && value.length > 0) {
-    components[key] = loadable((props) => import(`@kickstartds/base/lib/${props.component}/index.js`), {
-      resolveComponent: (exports) => exports[value[0]],
-    });
-  }
-});
-
-Object.entries(blogExports).forEach(([key, value]) => {
-  if (key.indexOf('/') === -1 && value.length > 0) {
-    components[key] = loadable((props) => import(`@kickstartds/blog/lib/${props.component}/index.js`), {
-      resolveComponent: (exports) => exports[value[0]],
-    });
-  }
-});
-
-Object.entries(contentExports).forEach(([key, value]) => {
-  if (key.indexOf('/') === -1 && value.length > 0) {
-    components[key] = loadable((props) => import(`@kickstartds/content/lib/${props.component}/index.js`), {
-      resolveComponent: (exports) => exports[value[0]],
-    });
-  }
-});
 
 const cleanFieldName = (fieldName) => fieldName.replace(/__.*/i, '');
 const cleanObjectKeys = (obj) => {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/gatsby-theme-kickstartds@1.7.1-canary.46.135.0
  # or 
  yarn add @kickstartds/gatsby-theme-kickstartds@1.7.1-canary.46.135.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
