### PR TITLE
remove `component` prop from any kds component

### DIFF
--- a/gatsby-theme-kickstartds/src/components/KickstartDSPageComponent.tsx
+++ b/gatsby-theme-kickstartds/src/components/KickstartDSPageComponent.tsx
@@ -66,7 +66,7 @@ const getComponent = (element, isSection = false) => {
     cleanedElement['headline'].type = 'headline';
 
     return (
-      <Component component={componentType} key={key} { ...cleanedElement }>
+      <Component key={key} { ...cleanedElement }>
         {getContent(content)}
       </Component>
     );
@@ -74,7 +74,7 @@ const getComponent = (element, isSection = false) => {
 
   const cleanedElement: Record<string, any> = cleanObjectKeys(element);
   const { typeProp, type, ...restElement } = cleanedElement;
-  return <Component type={typeProp} component={componentType} key={key} { ...restElement } />;
+  return <Component type={typeProp} key={key} { ...restElement } />;
 };
 
 const getContent = (content, sections = false) => {


### PR DESCRIPTION
https://github.com/kickstartDS/website/issues/135

Ich denke, diese `component` prop ist eine Altlast aus früheren dynamischen Component Loadern. Aktuell bewirkt sie, dass jede Komponente diese Prop bekommt und weil die meisten nichts damit anfangen können, werden sie als Attribut gerendert (kein Problem, aber nicht schön).

Die Slider-Komponente erwartet aber tatsächlich diese Prop und bekommt sie jetzt also von Gatsby und deshalb funktioniert der Quotes-Slider nicht.

@julrich, bitte mal gegenchecken, ob diese Prop wirklich überflüssig ist. Wenn ja, gerne direkt mergen.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/gatsby-theme-kickstartds@1.7.4-canary.47.144.0
  # or 
  yarn add @kickstartds/gatsby-theme-kickstartds@1.7.4-canary.47.144.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
