### PR TITLE
fix: de-activate analytics for now

### DIFF
--- a/gatsby-theme-kickstartds/create/createPages.js
+++ b/gatsby-theme-kickstartds/create/createPages.js
@@ -77,7 +77,7 @@ module.exports = async ({ actions, graphql }, options) => {
   await Promise.all(
     data.allKickstartDsPage.edges.map(async (page) => {
       if (!(page.node.slug.includes('blog') || page.node.slug.includes('glossary'))) {
-        await analyzeContent(page.node.slug, page.node.sections, true);
+        // await analyzeContent(page.node.slug, page.node.sections, true);
 
         await actions.createPage({
           component: require.resolve('../src/templates/page.js'),


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/gatsby-theme-kickstartds@1.15.2-canary.80.330.0
  # or 
  yarn add @kickstartds/gatsby-theme-kickstartds@1.15.2-canary.80.330.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
