### PR TITLE
fix: increase wordpress asset limit

### DIFF
--- a/gatsby-transformer-kickstartds-wordpress/gatsby-config.js
+++ b/gatsby-transformer-kickstartds-wordpress/gatsby-config.js
@@ -35,6 +35,11 @@ module.exports = {
         CoreParagraphBlockAttributesV2: {
           exclude: true,
         },
+        MediaItem: {
+          localFile: {
+            maxFileSizeBytes: 104857600,
+          },
+        }
       },
     },
   }],


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/gatsby-transformer-kickstartds-wordpress@1.9.5-canary.81.333.0
  # or 
  yarn add @kickstartds/gatsby-transformer-kickstartds-wordpress@1.9.5-canary.81.333.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
